### PR TITLE
Suppression de l'utilisation de la table commune du schéma layer

### DIFF
--- a/data/grant.sql
+++ b/data/grant.sql
@@ -35,4 +35,4 @@ GRANT SELECT ON TABLE atlas.vm_mois TO my_reader_user;
 GRANT SELECT ON TABLE atlas.vm_altitudes TO my_reader_user;
 GRANT EXECUTE ON FUNCTION atlas.find_all_taxons_childs(integer) TO my_reader_user;
 GRANT SELECT ON TABLE atlas.bib_taxref_rangs TO my_reader_user;
-
+GRANT SELECT ON TABLE atlas.t_mailles_territoire TO my_reader_user;


### PR DESCRIPTION
Juste une chose bizarre: dans la table `atlas.t_maille_territoire` il y a une champ geojson déjà calculé pendant l'installation de la base.
Quand j'essaye d'utiliser ce champs dans la requête, celle-ci met plus de 2 minutes. Quand je le recalcule à la volée en faisant un `ST_ASGEOJSON` du champs `the_geom`, la requête ne met plus que 100ms...

Vous pouvez tester : 
La requête rapide:
```
SELECT o.cd_ref, t.id_maille, ST_ASGEOJSON(ST_TRANSFORM(t.the_geom, 4326)) AS geojson_maille, extract(YEAR FROM o.dateobs) as annee
            FROM atlas.vm_observations o
            JOIN atlas.vm_communes c ON ST_INTERSECTS(o.the_geom_point, c.the_geom)  
            JOIN atlas.t_mailles_territoire t ON ST_INTERSECTS(t.the_geom, o.the_geom_point)
            WHERE o.cd_ref = 2960 AND c.insee = '05153'
            ORDER BY id_maille
```

La requête longue: 
```
SELECT o.cd_ref, t.id_maille, t.st_asgeojson, extract(YEAR FROM o.dateobs) as annee
            FROM atlas.vm_observations o
            JOIN atlas.vm_communes c ON ST_INTERSECTS(o.the_geom_point, c.the_geom)  
            JOIN atlas.t_mailles_territoire t ON ST_INTERSECTS(t.the_geom, o.the_geom_point)
            WHERE o.cd_ref = 2960 AND c.insee = '05153'
            ORDER BY id_maille
```

ça vient peut-être du fait que le champs en question de la table t_maille_territoire s'appelle `st_asgeojson`. Dans ce cas il faudrait le renommer lors de l'installation de la base.