### PR TITLE
[WIP] Maille lastobs

### DIFF
--- a/main/atlasAPI.py
+++ b/main/atlasAPI.py
@@ -39,6 +39,12 @@ def getObservationsMailleAPI(cd_ref):
     connection.close()
     return Response(json.dumps(observations), mimetype='application/json')
 
+@api.route('/observationsMailleLastObs/<int:cd_ref>',methods=['GET'])
+def getObservationsMailleLastObsAPI(cd_ref):
+    connection = utils.engine.connect()
+    observations = vmObservationsMaillesRepository.getObservationsMaillesLastObsChilds(connection, cd_ref)
+    connection.close()
+    return Response(json.dumps(observations), mimetype='application/json')
 
 @api.route('/observationsPoint/<int:cd_ref>', methods=['GET'])
 def getObservationsPointAPI(cd_ref):

--- a/main/atlasRoutes.py
+++ b/main/atlasRoutes.py
@@ -160,6 +160,7 @@ def ficheEspece(cd_ref):
         'PROTECTION': config.PROTECTION,
         'GLOSSAIRE': config.GLOSSAIRE,
         'AFFICHAGE_MAILLE': config.AFFICHAGE_MAILLE,
+        'TYPE_MAILLE': config.TYPE_MAILLE,
         'ZOOM_LEVEL_POINT': config.ZOOM_LEVEL_POINT,
         'LIMIT_CLUSTER_POINT': config.LIMIT_CLUSTER_POINT,
         'FICHE_ESPECE': True,

--- a/main/configuration/config.py.sample
+++ b/main/configuration/config.py.sample
@@ -64,6 +64,9 @@ MAP = {
 # True = maille / False = point
 AFFICHAGE_MAILLE = False
 
+#Couleur selon la dernière obs (<5 ans, 5 à 10 ans, +10 ans) "last obs" ou le nombre d'obs "nb obs"
+TYPE_MAILLE = 'nb obs'
+
 # Niveau de zoom à partir duquel on passe à l'affichage en point (si AFFICHAGE_MAILLE = False)
 ZOOM_LEVEL_POINT = 11
 

--- a/main/modeles/repositories/vmObservationsMaillesRepository.py
+++ b/main/modeles/repositories/vmObservationsMaillesRepository.py
@@ -38,7 +38,8 @@ def getObservationsMaillesLastObsChilds(connection, cd_ref):
         SELECT
             obs.id_maille,
             obs.geojson_maille,
-            max(date_part('year', o.dateobs)) as lastyear
+            max(date_part('year', o.dateobs)) as lastyear,
+            count(*) as nb_obs
         FROM atlas.vm_observations_mailles obs
         JOIN atlas.vm_observations o ON o.id_observation = obs.id_observation
         WHERE obs.cd_ref in (
@@ -51,10 +52,11 @@ def getObservationsMaillesLastObsChilds(connection, cd_ref):
     tabObs = list()
     for o in observations:
         temp = {
-            'properties':{
-            'id_maille': o.id_maille,
-            'nb_observations': 1,
-            'lastyear': o.lastyear},
+                'properties':{
+                'id_maille': o.id_maille,
+                'nb_observations': o.nb_obs,
+                'lastyear': o.lastyear
+            },
             'geometry': ast.literal_eval(o.geojson_maille),
             'type' : "Feature"
         }

--- a/main/modeles/repositories/vmObservationsMaillesRepository.py
+++ b/main/modeles/repositories/vmObservationsMaillesRepository.py
@@ -32,6 +32,32 @@ def getObservationsMaillesChilds(connection, cd_ref):
         tabObs.append(temp)
     return tabObs
 
+def getObservationsMaillesLastObsChilds(connection, cd_ref):
+    sql = """
+        SELECT
+            obs.id_maille,
+            obs.geojson_maille,
+            max(date_part('year', o.dateobs)) as lastyear
+        FROM atlas.vm_observations_mailles obs
+        JOIN atlas.vm_observations o ON o.id_observation = obs.id_observation
+        WHERE obs.cd_ref in (
+                SELECT * FROM atlas.find_all_taxons_childs(:thiscdref)
+            )
+            OR obs.cd_ref = :thiscdref
+	GROUP BY obs.id_maille, obs.geojson_maille
+        ORDER BY id_maille"""
+    observations = connection.execute(text(sql), thiscdref=cd_ref)
+    tabObs = list()
+    for o in observations:
+        temp = {
+            'id_maille': o.id_maille,
+            'nb_observations': 1,
+            'lasyear': o.lastyear,
+            'geojson_maille': ast.literal_eval(o.geojson_maille)
+        }
+        tabObs.append(temp)
+    return tabObs
+
 
 # last observation for index.html
 def lastObservationsMailles(connection, mylimit, idPhoto):

--- a/main/modeles/repositories/vmObservationsMaillesRepository.py
+++ b/main/modeles/repositories/vmObservationsMaillesRepository.py
@@ -32,6 +32,7 @@ def getObservationsMaillesChilds(connection, cd_ref):
         tabObs.append(temp)
     return tabObs
 
+#Maille avec date de derniere obs seulement
 def getObservationsMaillesLastObsChilds(connection, cd_ref):
     sql = """
         SELECT
@@ -50,13 +51,16 @@ def getObservationsMaillesLastObsChilds(connection, cd_ref):
     tabObs = list()
     for o in observations:
         temp = {
+            'properties':{
             'id_maille': o.id_maille,
             'nb_observations': 1,
-            'lasyear': o.lastyear,
-            'geojson_maille': ast.literal_eval(o.geojson_maille)
+            'lastyear': o.lastyear},
+            'geometry': ast.literal_eval(o.geojson_maille),
+            'type' : "Feature"
         }
         tabObs.append(temp)
-    return tabObs
+    outGeoJson={'type':"FeatureCollection", 'features':tabObs}
+    return outGeoJson
 
 
 # last observation for index.html

--- a/static/mapGenerator.js
+++ b/static/mapGenerator.js
@@ -593,7 +593,7 @@ function generateSliderOnMap(){
       },
 
     onAdd: function (map) {
-        var sliderContainer = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-slider-control');
+        sliderContainer = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-slider-control');
      
         sliderContainer.style.backgroundColor = 'white';
         sliderContainer.style.width = '300px';

--- a/static/mapMaillesLastObs.js
+++ b/static/mapMaillesLastObs.js
@@ -48,7 +48,11 @@ $.ajax({
     $('#loadingGif').hide();
 
   currentLayer = L.geoJson(observations, {
-      //onEachFeature : onEachFeatureMaille,
+      onEachFeature : function (feature, layer){
+                    popupContent = "<b>Nombre d'observations </b> "+feature.properties.nb_observations+"<br><b>Dernière d'observations </b>"+feature.properties.lastyear ;
+
+                layer.bindPopup(popupContent)
+      },
       style: styleMailleAtlas,
   }).addTo(map);
   currentLayer.bringToFront();

--- a/static/mapMaillesLastObs.js
+++ b/static/mapMaillesLastObs.js
@@ -47,10 +47,11 @@ $.ajax({
   }).done(function(observations) {
     $('#loadingGif').hide();
 
-   L.geoJson(observations, {
+  currentLayer = L.geoJson(observations, {
       //onEachFeature : onEachFeatureMaille,
       style: styleMailleAtlas,
   }).addTo(map);
+  currentLayer.bringToFront();
     /*    
     // affichage des mailles
     displayMailleLayerFicheEspece(observations, taxonYearMin, YEARMAX);

--- a/static/mapMaillesLastObs.js
+++ b/static/mapMaillesLastObs.js
@@ -30,8 +30,8 @@ function styleMailleAtlas(feature) {
 
     return {
         fillColor: fillColor,
-        weight: 2,
-        color: 'black',
+        weight: 0.5,
+        color: 'white',
         fillOpacity: 0.8
     };
 }

--- a/static/mapMaillesLastObs.js
+++ b/static/mapMaillesLastObs.js
@@ -1,0 +1,146 @@
+var map = generateMap();
+generateSliderOnMap();
+var legend = L.control({position: 'bottomright'});
+
+// Legende
+
+htmlLegend = "<i style='border: solid "+configuration.MAP.BORDERS_WEIGHT+"px "+configuration.MAP.BORDERS_COLOR+";'> &nbsp; &nbsp; &nbsp;</i> Limite du "+ configuration.STRUCTURE;
+generateLegende(htmlLegend);
+
+
+// Current observation Layer: leaflet layer type
+var currentLayer; 
+
+// Current observation geoJson:  type object
+var myGeoJson;
+
+var compteurLegend = 0; // compteur pour ne pas rajouter la légende à chaque fois
+
+function styleMailleAtlas(feature) {
+    var fillColor ;
+    var currentYear = new Date().getFullYear() ;
+    var obsyear = feature.properties.lastyear ;
+    if(feature.properties.lastyear <= currentYear - 10){
+        fillColor='red' ;
+    }else if(feature.properties.lastyear <= currentYear - 5) {
+        fillColor='yellow';
+    }else{
+        fillColor='green';
+    }
+
+    return {
+        fillColor: fillColor,
+        weight: 2,
+        color: 'black',
+        fillOpacity: 0.8
+    };
+}
+
+L.DomUtil.remove(sliderContainer); //Remove slider created in mapGenerator.js
+
+$.ajax({
+  url: configuration.URL_APPLICATION+'/api/observationsMailleLastObs/'+cd_ref, 
+  dataType: "json",
+  beforeSend: function(){
+    $('#loadingGif').attr('src', configuration.URL_APPLICATION+'/static/images/loading.svg')
+  }
+  }).done(function(observations) {
+    $('#loadingGif').hide();
+
+   L.geoJson(observations, {
+      //onEachFeature : onEachFeatureMaille,
+      style: styleMailleAtlas,
+  }).addTo(map);
+    /*    
+    // affichage des mailles
+    displayMailleLayerFicheEspece(observations, taxonYearMin, YEARMAX);
+
+      //display nb observations
+  $("#nbObsLateral").html("<b>"+observations.length+" </b> </br> Observations" );
+
+
+
+    // pointer on first and last obs
+    $('.pointer').css('cursor', 'pointer');
+    //display nb observations
+        nbObs=0;
+        myGeoJson.features.forEach(function(l){
+          nbObs += l.properties.nb_observations
+          })
+        $("#nbObs").html("Nombre d'observation(s): "+ nbObs);
+   
+
+
+     // Slider event
+    mySlider.on("change",function(){
+          years = mySlider.getValue();
+          yearMin = years[0];
+          yearMax = years[1];
+          map.removeLayer(currentLayer);
+          displayMailleLayerFicheEspece(observations, yearMin, yearMax)
+
+
+        nbObs=0;
+        myGeoJson.features.forEach(function(l){
+          nbObs += l.properties.nb_observations
+        })
+
+        $("#nbObs").html("Nombre d'observation(s): "+ nbObs);
+
+       });
+
+
+    // Stat - map interaction
+    $('#firstObs').click(function(){
+      var firstObsLayer;
+      var year = new Date('2400-01-01');
+
+
+          var layer = (currentLayer._layers);
+          for (var key in layer) {
+            layer[key].feature.properties.tabDateobs.forEach(function(thisYear){
+              if (thisYear <= year){
+                year = thisYear;
+                firstObsLayer = layer[key];
+              }
+            });
+          }
+
+          
+          var bounds = L.latLngBounds([]);
+          var layerBounds = firstObsLayer.getBounds();
+          bounds.extend(layerBounds);
+          map.fitBounds(bounds, {
+            maxZoom : 12
+          });
+
+          firstObsLayer.openPopup();
+    })
+
+    $('#lastObs').click(function(){
+      var firstObsLayer;
+      var year = new Date('1800-01-01');
+
+
+          var layer = (currentLayer._layers);
+          for (var key in layer) {
+            layer[key].feature.properties.tabDateobs.forEach(function(thisYear){
+              if (thisYear >= year){
+                year = thisYear;
+                firstObsLayer = layer[key];
+              }
+            });
+          }
+
+          
+          var bounds = L.latLngBounds([]);
+          var layerBounds = firstObsLayer.getBounds();
+          bounds.extend(layerBounds);
+          map.fitBounds(bounds, {
+            maxZoom : 12
+          });
+
+          firstObsLayer.openPopup();
+    })*/
+});
+

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -553,7 +553,11 @@
     <script src="{{url_for('static', filename='mapGenerator.js') }}"></script>
     <script src="{{url_for('static', filename='main.js') }}"></script>
     {% if configuration.AFFICHAGE_MAILLE %}
+        {% if configuration.TYPE_MAILLE == "last obs" %}
+        <script src="{{url_for('static', filename='mapMaillesLastObs.js') }}"></script>
+        {% else %}
         <script src="{{url_for('static', filename='mapMailles.js') }}"></script>
+        {% endif %}
     {% else %}
         <script src="{{url_for('static', filename='mapPoint.js') }}"></script>
     {% endif %}


### PR DESCRIPTION
Ajout d'une config pour l'affichage par maille permettant de n'afficher que la dernière année d'observation (vert < 5 ans, jaune 5 à 10 ans, rouge > 10 ans). Ceci permet de mettre en avant les mailles à ré-actualiser.
Une route pour l'API est ajoutée, permettant au client de ne pas charger toutes les données, mais juste maille et derniere année d'obs.
