### PR TITLE
Install db

### DIFF
--- a/atlas/configuration/settings.ini.sample
+++ b/atlas/configuration/settings.ini.sample
@@ -35,6 +35,23 @@ geonature_version=2
 # true : base de données distante
 geonature_fdw=true
 
+
+#####################################################################
+#####    PARAMETRES CUSTOM DE CONNEXION A LA BASE DE DONNEE    ######
+#####    EN TANT QU'ADMINISTRATEUR POUR BDD DISTANTE           ######
+#####################################################################
+# Paramètres à utiliser uniquement si le serveur de base de données de l'atlas est distant
+# si "custom_db_admin" vaut "true"
+
+# custom db admin role (not postgres, almost used when using distant database)
+custom_db_admin=false
+# db admin username
+db_admin_name=dbadmin
+# db admin password
+db_admin_pass=dbadminpass
+# default admin database, if different from postgres
+db_admin_default_db=postgres
+
 ################################################
 ##### CONNEXION A LA BDD GEONATURE SOURCE ######
 ################################################

--- a/install_db.sh
+++ b/install_db.sh
@@ -24,14 +24,14 @@ function database_exists () {
         return 0
     else
         # Grep db name in the list of database
-        sudo -n -u postgres -s -- psql -tAl | grep -q "^$1|"
+        $psql_command_admindb -tAl | grep -q "^$1|"
         return $?
     fi
 }
 
 function test_settings() {
     fields=('owner_atlas' 'user_pg' 'altitudes' 'time' 'attr_desc' 'attr_commentaire' 'attr_milieu' 'attr_chorologie')
-    echo "Vérification de la validité de settings.ini"
+    echo "## Vérification de la validité de settings.ini"
     for i in "${!fields[@]}"
     do
         if [ -z ${!fields[$i]} ];
@@ -42,7 +42,25 @@ function test_settings() {
     done
 }
 
+
 test_settings
+
+
+if $custom_db_admin
+then
+  echo "Use distant database"
+  psql_command_admindb="psql postgresql://${db_admin_name}:${db_admin_pass}@${db_host}:${db_port}/${db_admin_default_db}"
+  psql_command_atlasdb="psql postgresql://${db_admin_name}:${db_admin_pass}@${db_host}:${db_port}/${db_name}"
+  which $psql_command_admindb
+else
+  echo "Use local database" &>> log/install_db.log
+  psql_command_admindb="sudo -u postgres psql"
+  psql_command_atlasdb="sudo -u postgres psql -d ${db_name}"
+fi
+
+echo "$psql_command_admindb"
+
+$psql_command_admindb -tAl
 
 # Suppression du fichier de log d'installation si il existe déjà puis création de ce fichier vide.
 rm  -f ./log/install_db.log
@@ -53,53 +71,55 @@ if database_exists $db_name
 then
         if $drop_apps_db
             then
-            echo "Suppression de la BDD..."
-            sudo -n -u postgres -s dropdb $db_name  &>> log/install_db.log
+            echo "## Suppression de la BDD..."
+            $psql_command_admindb -c "DROP DATABASE $db_name"  &>> log/install_db.log
         else
-            echo "La base de données existe et le fichier de settings indique de ne pas la supprimer."
+            echo "## La base de données existe et le fichier de settings indique de ne pas la supprimer."
         fi
 fi
+
+export owner_atlas_connstring=postgresql://$owner_atlas:$owner_atlas_pass@$db_host:$db_port/$db_name
+echo $owner_atlas_connstring
 
 # Sinon je créé la BDD
 if ! database_exists $db_name
 then
 
-	echo "Création de la BDD..."
+	echo "## Création de la BDD..."
 
-    sudo -u postgres psql -c "CREATE USER $owner_atlas WITH PASSWORD '$owner_atlas_pass' "  &>> log/install_db.log
-    sudo -u postgres psql -c "CREATE USER $user_pg WITH PASSWORD '$user_pg_pass' "  &>> log/install_db.log
-    sudo -n -u postgres -s createdb -O $owner_atlas $db_name
-    echo "Ajout de postGIS et pgSQL à la base de données"
-    sudo -n -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgis;"  &>> log/install_db.log
-    sudo -n -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog; COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';"  &>> log/install_db.log
-    sudo -n -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;" &>> log/install_db.log
+    $psql_command_admindb -c "CREATE ROLE $owner_atlas WITH LOGIN ENCRYPTED PASSWORD '$owner_atlas_pass' "  &>> log/install_db.log
+    $psql_command_admindb -c "CREATE ROLE $user_pg WITH LOGIN ENCRYPTED PASSWORD '$user_pg_pass' "  &>> log/install_db.log
+    $psql_command_admindb -c "CREATE DATABASE $db_name OWNER $owner_atlas   LC_COLLATE 'fr_FR.utf8' LC_CTYPE 'fr_FR.utf8' ENCODING UTF8 TEMPLATE template0"  &>> log/install_db.log
+
+    echo "## Ajout de postGIS et pgSQL à la base de données"
+    $psql_command_atlasdb -c "CREATE EXTENSION IF NOT EXISTS postgis;"  &>> log/install_db.log
+    $psql_command_atlasdb -c "CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog; COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';"  &>> log/install_db.log
+    $psql_command_atlasdb -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;" &>> log/install_db.log
     # Si j'utilise GeoNature ($geonature_source = True), alors je créé les connexions en FWD à la BDD GeoNature
     if $geonature_source
 	then
-        echo "Ajout du FDW et connexion à la BDD mère GeoNature"
-        sudo -n -u postgres -s psql -d $db_name -c "CREATE EXTENSION IF NOT EXISTS postgres_fdw;"  &>> log/install_db.log
-        sudo -n -u postgres -s psql -d $db_name -c "CREATE SERVER geonaturedbserver FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host '$db_source_host', dbname '$db_source_name', port '$db_source_port');"  &>> log/install_db.log
-        sudo -n -u postgres -s psql -d $db_name -c "ALTER SERVER geonaturedbserver OWNER TO $owner_atlas;"  &>> log/install_db.log
-        sudo -n -u postgres -s psql -d $db_name -c "CREATE USER MAPPING FOR $owner_atlas SERVER geonaturedbserver OPTIONS (user '$atlas_source_user', password '$atlas_source_pass') ;"  &>> log/install_db.log
+        echo "## Ajout du FDW et connexion à la BDD mère GeoNature"
+        $psql_command_atlasdb -c "CREATE EXTENSION IF NOT EXISTS postgres_fdw;"  &>> log/install_db.log
+        $psql_command_atlasdb -c "CREATE SERVER geonaturedbserver FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host '$db_source_host', dbname '$db_source_name', port '$db_source_port');"  &>> log/install_db.log
+        $psql_command_atlasdb -c "ALTER SERVER geonaturedbserver OWNER TO $owner_atlas;"  &>> log/install_db.log
+        $psql_command_atlasdb -c "CREATE USER MAPPING FOR $owner_atlas SERVER geonaturedbserver OPTIONS (user '$atlas_source_user', password '$atlas_source_pass') ;"  &>> log/install_db.log
     fi
 
     # Création des schémas de la BDD
-    sudo -n -u postgres -s psql -d $db_name -c "CREATE SCHEMA atlas AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
+    $psql_command_atlasdb -c "CREATE SCHEMA atlas AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
 	if [ $install_taxonomie = "false" ]
 	then
-        sudo -n -u postgres -s psql -d $db_name -c "CREATE SCHEMA taxonomie AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
+        $psql_command_atlasdb -c "CREATE SCHEMA taxonomie AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
     fi
-	sudo -n -u postgres -s psql -d $db_name -c "CREATE SCHEMA synthese AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
+	$psql_command_atlasdb -c "CREATE SCHEMA synthese AUTHORIZATION "$owner_atlas";"  &>> log/install_db.log
 
     if $geonature_source
 	then
         if test $geonature_version -eq 2
         then
-            echo "Création des FDW depuis GN2"
+            echo "## Création des FDW depuis GN2"
             echo "--------------------" &>> log/install_db.log
-            echo "Création des FDW depuis GN2" &>> log/install_db.log
-            echo "--------------------" &>> log/install_db.log
-            export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f data/gn2/atlas_gn2.sql  &>> log/install_db.log
+            psql $owner_atlas_connstring -f data/gn2/atlas_gn2.sql  &>> log/install_db.log
         fi
     fi
 
@@ -109,32 +129,32 @@ then
         echo "--------------------" &>> log/install_db.log
         echo "Creation of layers table from ref_geo of geonaturedb" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port \
+        psql $owner_atlas_connstring \
             -v type_maille=$type_maille -v type_territoire=$type_territoire -f data/gn2/atlas_ref_geo.sql &>> log/install_db.log
     else
         # Import du shape des limites du territoire ($limit_shp) dans la BDD / atlas.t_layer_territoire
         ogr2ogr -f "ESRI Shapefile" -t_srs EPSG:3857 data/ref/emprise_territoire_3857.shp $limit_shp
-        sudo -n -u postgres -s shp2pgsql -W "LATIN1" -s 3857 -D -I ./data/ref/emprise_territoire_3857.shp atlas.t_layer_territoire | sudo -n -u postgres -s psql -d $db_name  &>> log/install_db.log
+        sudo shp2pgsql -W "LATIN1" -s 3857 -D -I ./data/ref/emprise_territoire_3857.shp atlas.t_layer_territoire | $psql_command_atlasdb &>> log/install_db.log
         rm data/ref/emprise_territoire_3857.*
-        sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.t_layer_territoire OWNER TO "$owner_atlas";"
+        $psql_command_atlasdb -c "ALTER TABLE atlas.t_layer_territoire OWNER TO "$owner_atlas";"
         # Creation de l'index GIST sur la couche territoire atlas.t_layer_territoire
-        sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.t_layer_territoire RENAME COLUMN geom TO the_geom; CREATE INDEX index_gist_t_layer_territoire ON atlas.t_layer_territoire USING gist(the_geom); "  &>> log/install_db.log
+        $psql_command_atlasdb -c "ALTER TABLE atlas.t_layer_territoire RENAME COLUMN geom TO the_geom; CREATE INDEX index_gist_t_layer_territoire ON atlas.t_layer_territoire USING gist(the_geom); "  &>> log/install_db.log
 
         # Import du shape des communes ($communes_shp) dans la BDD (si parametre import_commune_shp = TRUE) / atlas.l_communes
         if $import_commune_shp
         then
             ogr2ogr -f "ESRI Shapefile" -t_srs EPSG:3857 ./data/ref/communes_3857.shp $communes_shp
-            sudo -n -u postgres -s shp2pgsql -W "LATIN1" -s 3857 -D -I ./data/ref/communes_3857.shp atlas.l_communes | sudo -n -u postgres -s psql -d $db_name  &>> log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.l_communes RENAME COLUMN "$colonne_nom_commune" TO commune_maj;"  &>> log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.l_communes RENAME COLUMN "$colonne_insee" TO insee;"  &>> log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.l_communes RENAME COLUMN geom TO the_geom;"  &>> log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "CREATE INDEX index_gist_t_layers_communes ON atlas.l_communes USING gist (the_geom);"  &>> log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.l_communes OWNER TO "$owner_atlas";"
+            shp2pgsql -W "LATIN1" -s 3857 -D -I ./data/ref/communes_3857.shp atlas.l_communes | $psql_command_atlasdb  &>> log/install_db.log
+            $psql_command_atlasdb -c "ALTER TABLE atlas.l_communes RENAME COLUMN "$colonne_nom_commune" TO commune_maj;"  &>> log/install_db.log
+            $psql_command_atlasdb -c "ALTER TABLE atlas.l_communes RENAME COLUMN "$colonne_insee" TO insee;"  &>> log/install_db.log
+            $psql_command_atlasdb -c "ALTER TABLE atlas.l_communes RENAME COLUMN geom TO the_geom;"  &>> log/install_db.log
+            $psql_command_atlasdb -c "CREATE INDEX index_gist_t_layers_communes ON atlas.l_communes USING gist (the_geom);"  &>> log/install_db.log
+            $psql_command_atlasdb -c "ALTER TABLE atlas.l_communes OWNER TO "$owner_atlas";"
             rm ./data/ref/communes_3857.*
         fi
 
         # Mise en place des mailles
-        echo "Découpage des mailles et creation de la table des mailles"
+        echo "## Découpage des mailles et creation de la table des mailles"
 
         cd data/ref
         rm -f L93*.dbf L93*.prj L93*.sbn L93*.sbx L93*.shp L93*.shx
@@ -151,14 +171,14 @@ then
             ogr2ogr -f "ESRI Shapefile" -t_srs EPSG:3857 ./mailles_5.shp L93_5K.shp
             ogr2ogr -f "ESRI Shapefile" -t_srs EPSG:3857 ./mailles_10.shp L93_10K.shp
             # J'importe dans la BDD le SHP des mailles à l'échelle définie en parametre ($taillemaille)
-            sudo -n -u postgres -s shp2pgsql -W "LATIN1" -s 3857 -D -I mailles_$taillemaille.shp atlas.t_mailles_$taillemaille | sudo -n -u postgres -s psql -d $db_name  &>> ../../log/install_db.log
-            sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.t_mailles_"$taillemaille" OWNER TO "$owner_atlas";"
+            shp2pgsql -W "LATIN1" -s 3857 -D -I mailles_$taillemaille.shp atlas.t_mailles_$taillemaille | $psql_command_atlasdb  &>> ../../log/install_db.log
+            $psql_command_atlasdb -c "ALTER TABLE atlas.t_mailles_"$taillemaille" OWNER TO "$owner_atlas";"
             rm mailles_1.* mailles_5.* mailles_10.*
 
             cd ../../
 
             # Creation de la table atlas.t_mailles_territoire avec la taille de maille passée en parametre ($taillemaille). Pour cela j'intersecte toutes les mailles avec mon territoire
-            sudo -n -u postgres -s psql -d $db_name -c "CREATE TABLE atlas.t_mailles_territoire as
+            $psql_command_atlasdb -c "CREATE TABLE atlas.t_mailles_territoire as
                                                         SELECT m.geom AS the_geom, ST_AsGeoJSON(st_transform(m.geom, 4326)) as geojson_maille
                                                         FROM atlas.t_mailles_"$taillemaille" m, atlas.t_layer_territoire t
                                                         WHERE ST_Intersects(m.geom, t.the_geom);
@@ -172,9 +192,9 @@ then
         # Sinon j'utilise un SHP des mailles fournies par l'utilisateur
         else
             ogr2ogr -f "ESRI Shapefile" -t_srs EPSG:3857 custom_mailles_3857.shp $chemin_custom_maille
-            sudo -n -u postgres -s shp2pgsql -W "LATIN1" -s 3857 -D -I custom_mailles_3857.shp atlas.t_mailles_custom | sudo -n -u postgres -s psql -d $db_name  &>> log/install_db.log
+            shp2pgsql -W "LATIN1" -s 3857 -D -I custom_mailles_3857.shp atlas.t_mailles_custom | $psql_command_atlasdb  &>> log/install_db.log
 
-            sudo -n -u postgres -s psql -d $db_name -c "CREATE TABLE atlas.t_mailles_territoire as
+            $psql_command_atlasdb -c "CREATE TABLE atlas.t_mailles_territoire as
                                                 SELECT m.geom AS the_geom, ST_AsGeoJSON(st_transform(m.geom, 4326)) as geojson_maille
                                                 FROM atlas.t_mailles_custom m, atlas.t_layer_territoire t
                                                 WHERE ST_Intersects(m.geom, t.the_geom);
@@ -186,7 +206,7 @@ then
                                                 ALTER TABLE atlas.t_mailles_territoire
                                                 ADD PRIMARY KEY (id_maille);"  &>> log/install_db.log
         fi
-        sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.t_mailles_territoire OWNER TO "$owner_atlas";"
+        $psql_command_atlasdb -c "ALTER TABLE atlas.t_mailles_territoire OWNER TO "$owner_atlas";"
     fi
 
 
@@ -229,7 +249,7 @@ then
         echo "Creating 'taxonomie' schema" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/taxhub/taxhubdb.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/taxhubdb.sql  &>> log/install_db.log
 
         echo "Inserting INPN taxonomic data... (This may take a few minutes)"
         echo "" &>> log/install_db.log
@@ -238,7 +258,7 @@ then
         echo "Inserting INPN taxonomic data" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        sudo -n -u postgres -s psql -d $db_name -f /tmp/taxhub/data_inpn_taxhub.sql &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/data_inpn_taxhub.sql &>> log/install_db.log
 
         echo "Creating dictionaries data for taxonomic schema..."
         echo "" &>> log/install_db.log
@@ -247,7 +267,7 @@ then
         echo "Creating dictionaries data for taxonomic schema" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/taxhub/taxhubdata.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/taxhubdata.sql  &>> log/install_db.log
 
         echo "Inserting sample dataset of taxons for taxonomic schema..."
         echo "" &>> log/install_db.log
@@ -256,13 +276,13 @@ then
         echo "Inserting sample dataset of taxons for taxonomic schema" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/taxhub/taxhubdata_taxons_example.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/taxhubdata_taxons_example.sql  &>> log/install_db.log
 
         echo "--------------------" &>> log/install_db.log
         echo "Inserting sample dataset  - atlas attributes" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/taxhub/taxhubdata_atlas.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/taxhubdata_atlas.sql  &>> log/install_db.log
 
         echo "Creating a view that represent the taxonomic hierarchy..."
         echo "" &>> log/install_db.log
@@ -271,14 +291,14 @@ then
         echo "Creating a view that represent the taxonomic hierarchy" &>> log/install_db.log
         echo "--------------------" &>> log/install_db.log
         echo "" &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/taxhub/materialized_views.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/taxhub/materialized_views.sql  &>> log/install_db.log
     elif $geonature_source
     then
         # Creation des tables filles en FWD
         echo "Création de la connexion a GeoNature pour la taxonomie"
 		sudo cp data/gn2/atlas_ref_taxonomie.sql /tmp/atlas_ref_taxonomie.sql &>> log/install_db.log
         sudo sed -i "s/myuser;$/$owner_atlas;/" /tmp/atlas_ref_taxonomie.sql &>> log/install_db.log
-        export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas_ref_taxonomie.sql  &>> log/install_db.log
+        psql $owner_atlas_connstring -f /tmp/atlas_ref_taxonomie.sql  &>> log/install_db.log
     fi
 
 
@@ -292,19 +312,19 @@ then
             echo "Création de la connexion a GeoNature"
             sudo cp data/atlas_geonature.sql /tmp/atlas_geonature.sql
             sudo sed -i "s/myuser;$/$owner_atlas;/" /tmp/atlas_geonature.sql
-            export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas_geonature.sql  &>> log/install_db.log
+            psql $owner_atlas_connstring -f /tmp/atlas_geonature.sql  &>> log/install_db.log
         elif test $geonature_version -eq 2
         then
             sudo cp data/gn2/atlas_synthese.sql /tmp/atlas_synthese.sql
             sudo sed -i "s/myuser;$/$owner_atlas;/" /tmp/atlas_synthese.sql
-            export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -p $db_port -f /tmp/atlas_synthese.sql  &>> log/install_db.log
+            psql $owner_atlas_connstring -f /tmp/atlas_synthese.sql  &>> log/install_db.log
         else
             echo "Version de geonature $geonature_version non supportée"
         fi
     # Sinon je créé une table synthese.syntheseff avec 2 observations exemple
 	else
 		echo "Création de la table exemple syntheseff"
-		sudo -n -u postgres -s psql -d $db_name -c "CREATE TABLE synthese.syntheseff
+		$psql_command_atlasdb -c "CREATE TABLE synthese.syntheseff
 			(
 			  id_synthese serial PRIMARY KEY,
 			  id_organisme integer DEFAULT 2,
@@ -324,7 +344,7 @@ then
 			INSERT INTO synthese.syntheseff
 			  (cd_nom, insee, observateurs, altitude_retenue, the_geom_point, effectif_total, diffusion_level)
 			  VALUES (67111, 05122, 'Mon observateur 3', 940, '0101000020110F00001F548906D05E25413391E5EE2B795541', 2, 5);" &>> log/install_db.log
-        sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE synthese.syntheseff OWNER TO "$owner_atlas";"
+        $psql_command_atlasdb -c "ALTER TABLE synthese.syntheseff OWNER TO "$owner_atlas";"
 	fi
 
     # Creation des Vues Matérialisées (et remplacement éventuel des valeurs en dur par les paramètres)
@@ -350,23 +370,23 @@ then
     sudo sed -i "s/INSERT_ALTITUDE/${insert}/" /tmp/atlas.sql
 
 
-    export PGPASSWORD=$owner_atlas_pass;psql -d $db_name -U $owner_atlas -h $db_host -f /tmp/atlas.sql  &>> log/install_db.log
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.bib_altitudes OWNER TO "$owner_atlas";"
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.bib_taxref_rangs OWNER TO "$owner_atlas";"
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.bib_taxref_rangs OWNER TO "$owner_atlas";"
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER FUNCTION atlas.create_vm_altitudes() OWNER TO "$owner_atlas";"
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER FUNCTION atlas.find_all_taxons_childs(integer) OWNER TO "$owner_atlas";"
+    psql $owner_atlas_connstring -f /tmp/atlas.sql  &>> log/install_db.log
+    $psql_command_atlasdb -c "ALTER TABLE atlas.bib_altitudes OWNER TO "$owner_atlas";"
+    $psql_command_atlasdb -c "ALTER TABLE atlas.bib_taxref_rangs OWNER TO "$owner_atlas";"
+    $psql_command_atlasdb -c "ALTER TABLE atlas.bib_taxref_rangs OWNER TO "$owner_atlas";"
+    $psql_command_atlasdb -c "ALTER FUNCTION atlas.create_vm_altitudes() OWNER TO "$owner_atlas";"
+    $psql_command_atlasdb -c "ALTER FUNCTION atlas.find_all_taxons_childs(integer) OWNER TO "$owner_atlas";"
 
     echo "Creation de la VM des observations de chaque taxon par mailles..."
     # Création de la vue matérialisée vm_mailles_observations (nombre d'observations par maille et par taxon)
-    sudo -n -u postgres -s psql -d $db_name -f data/observations_mailles.sql  &>> log/install_db.log
-    sudo -n -u postgres -s psql -d $db_name -c "ALTER TABLE atlas.vm_observations_mailles OWNER TO "$owner_atlas";"
+    $psql_command_atlasdb -f data/observations_mailles.sql  &>> log/install_db.log
+    $psql_command_atlasdb -c "ALTER TABLE atlas.vm_observations_mailles OWNER TO "$owner_atlas";"
 
     # Affectation de droits en lecture sur les VM à l'utilisateur de l'application ($user_pg)
     echo "Grant..."
     sudo cp data/grant.sql /tmp/grant.sql
     sudo sed -i "s/my_reader_user;$/$user_pg;/" /tmp/grant.sql
-    sudo -n -u postgres -s psql -d $db_name -f /tmp/grant.sql &>> log/install_db.log
+    $psql_command_atlasdb -f /tmp/grant.sql &>> log/install_db.log
 
     # Clean file
     cd data/ref
@@ -378,3 +398,4 @@ then
     fi
 
 fi
+

--- a/install_db.sh
+++ b/install_db.sh
@@ -54,8 +54,8 @@ then
   which $psql_command_admindb
 else
   echo "Use local database" &>> log/install_db.log
-  psql_command_admindb="sudo -u postgres psql"
-  psql_command_atlasdb="sudo -u postgres psql -d ${db_name}"
+  psql_command_admindb="sudo -u postgres psql -p ${db_port}"
+  psql_command_atlasdb="sudo -u postgres psql -p ${db_port} -d ${db_name}"
 fi
 
 echo "$psql_command_admindb"


### PR DESCRIPTION
Mise à jour du script `install_db.sh` et `settings.ini.sample` offrant la possibilité d'installer la base de données atlas sur une base de données distante. 

Si on choisi l'install sur une base de donnée local, alors on utilise les `sudo su postgres` comme jusqu'à maintenant mais avec le port spécifié en plus. Sinon, on renseigne les paramètres du compte admin de la bdd distante, ainsi qu'une bdd générique (généralement `postgres`) et le `psql` utilise alors une chaîne de connexion de type
`psql postgresql://dbuser:dbpass@dbhost:dbport/dbname -c 'ma requête'` 