### PR TITLE
Ajout d'un message paramétrable sous les cartes (fiches espèces et communes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ atlas/configuration/config.py
 atlas/configuration/settings.ini
 robots.txt
 .htaccess
+.htpasswd
 venv/*
 venv3/*
 

--- a/atlas/configuration/config_schema.py
+++ b/atlas/configuration/config_schema.py
@@ -46,6 +46,7 @@ class MapConfig(Schema):
     BORDERS_COLOR = fields.String(missing="#000000")
     BORDERS_WEIGHT = fields.Integer(missing=3)
     ENABLE_SLIDER = fields.Boolean(missing=True)
+    INFO_MAP = fields.Boolean(missing=True)
 
 
 class AtlasConfig(Schema):

--- a/install_app.sh
+++ b/install_app.sh
@@ -80,6 +80,9 @@ fi
 if [ ! -f ./static/custom/templates/mentions-legales.html ]; then
   cp ./static/custom/templates/mentions-legales.html.sample ./static/custom/templates/mentions-legales.html
 fi
+if [ ! -f ./static/custom/templates/info_map.html ]; then
+  cp ./static/custom/templates/info_map.html.sample ./static/custom/templates/info_map.html
+fi
 if [ ! -f ./static/custom/custom.css ]; then
   cp ./static/custom/custom.css.sample ./static/custom/custom.css
 fi

--- a/static/css/atlas.css
+++ b/static/css/atlas.css
@@ -110,6 +110,11 @@ a {
   top: 40px;
 }
 
+.msg_map {
+  background-color: white !important;
+  border-color: var(--main-color) !important;
+}
+
 /* Navbar */
 
 .navbar {

--- a/static/custom/templates/info_map.html
+++ b/static/custom/templates/info_map.html
@@ -1,0 +1,9 @@
+<!-- Message d'information sous les cartes des fiches espèces et communes -->
+
+	<div class="row">
+	    <div class="col-sm-12">
+	        <p class="alert msg_map text-justify" style="margin:0px;">
+	        	<b>Informations importantes :</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+	        </p>
+	    </div>
+	</div>

--- a/static/custom/templates/info_map.html.sample
+++ b/static/custom/templates/info_map.html.sample
@@ -1,0 +1,9 @@
+<!-- Message d'information sous les cartes des fiches espèces et communes -->
+
+	<div class="row">
+	    <div class="col-sm-12">
+	        <p class="alert msg_map text-justify" style="margin:0px;">
+	        	<b>Informations importantes :</b> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+	        </p>
+	    </div>
+	</div>

--- a/templates/ficheCommune.html
+++ b/templates/ficheCommune.html
@@ -74,6 +74,9 @@
 							 <div id="map"> </div>
 						</div>
 					</div>
+                    {% if configuration.MAP.INFO_MAP %}
+                        {% include 'static/custom/templates/info_map.html' %}
+                    {% endif %}
 				</div>
             </div>
 

--- a/templates/ficheEspece.html
+++ b/templates/ficheEspece.html
@@ -296,6 +296,10 @@
                 </div>
             </div>
 
+            {% if configuration.MAP.INFO_MAP %}
+                {% include 'static/custom/templates/info_map.html' %}
+            {% endif %}
+
             <div class="panel panel-default" id="otherInformationsPanel">
                 <div class="row" id="otherInformations">
                           <ul class="nav nav-tabs">


### PR DESCRIPTION
Ajout d'un petit encart avec un message sous les cartes des fiches espèces et fiches communes afin de diffuser un avertissement aux utilisateurs concernant les données diffusées sur l'atlas.


- **Financement : CEN Pays de la Loire**

- Affichage oui /non avec le param INFO_MAP

- Si affichage = True, le message apparaît sous les cartes des fiches espèces et des fiches communes

- Message modifiable dans le template static/custom/templates/info_map.html
