### PR TITLE
Refactor vm_observation_maille to cor_maille_observation

### DIFF
--- a/atlas/atlasAPI.py
+++ b/atlas/atlasAPI.py
@@ -44,9 +44,9 @@ if not current_app.config["AFFICHAGE_MAILLE"]:
         :returns: dict ({'point:<GeoJson>', 'maille': 'GeoJson})
         """
         observations = {
-            "point": vmObservationsRepository.searchObservationsChilds(cd_ref),
+            "point": vmObservationsRepository.getObservationsChilds(filters={"cd_ref": cd_ref}),
             "maille": vmObservationsMaillesRepository.getObservationsMaillesChilds(
-                fiters={"cd_ref": cd_ref}
+                filters={"cd_ref": cd_ref}
             ),
         }
         return jsonify(observations)
@@ -83,44 +83,33 @@ def getObservationsMailleAPI():
 
 if not current_app.config["AFFICHAGE_MAILLE"]:
 
-    @api.route("/observationsPoint/<int(signed=True):cd_ref>", methods=["GET"])
-    def getObservationsPointAPI(cd_ref):
-        observations = vmObservationsRepository.searchObservationsChilds(cd_ref)
-        return jsonify(observations)
+    @api.route("/observationsPoint", methods=["GET"])
+    def getObservationsPointAPI():
+        """
+        Retourne un geojson des observations en point
+        Le geojson contient les propriétés présentes dans VMObservation
+        + taxon (optionnel: si with taxon est True) : le taxon de l'observation sous forme 'nom_vern | lb_nom'
 
+        Parameters
+        ----------
+        filters : dict, optional
+            dictionnaire des filtres de la query
+            Filtres disponible :
+                - year_min / year_max : filtre les observation dans des bornes d'année
+                - cd_ref : renvoie que les observation de ce taxon et de ces enfants
+                - id_area : renvoie uniquement les observations présente dans l'aire demandée
+                - limit : limite le nombre de résultat
 
-@api.route("/observations/<int(signed=True):cd_ref>", methods=["GET"])
-def getObservationsGenericApi(cd_ref: int):
-    """[summary]
-
-    Args:
-        cd_ref (int):
-
-    Returns:
-        [type]: [description]
-    """
-    if current_app.config["AFFICHAGE_MAILLE"]:
-        observations = vmObservationsMaillesRepository.getObservationsMaillesChilds(
-            filters={
-                "cd_ref": cd_ref,
-                "year_min": request.args.get("year_min"),
-                "year_max": request.args.get("year_max"),
-            }
-        )
-    else:
-        observations = vmObservationsRepository.searchObservationsChilds(session, cd_ref)
-
-    return jsonify(observations)
-
-
-if not current_app.config["AFFICHAGE_MAILLE"]:
-
-    @api.route("/observations/<id_area>/<int(signed=True):cd_ref>", methods=["GET"])
-    def getObservationsAreaTaxonAPI(id_area, cd_ref):
-        observations = vmObservationsRepository.getObservationTaxonArea(
-            id_area, cd_ref
+        Returns
+        -------
+        Geosjon
+        """
+        observations = vmObservationsRepository.getObservationsChilds(
+            request.args,
+            with_taxons=request.args.get("with_taxons", False)
         )
         return jsonify(observations)
+
 
 
 

--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -113,8 +113,7 @@ if current_app.config["ORGANISM_MODULE"]:
 def index():
 
     if current_app.config["AFFICHAGE_TERRITOIRE_OBS"]:
-        # listTaxons = vmTaxonsRepository.getTaxonsTerritory()
-        listTaxons = []
+        listTaxons = vmTaxonsRepository.getTaxonsTerritory()
     else:
         listTaxons = []
 
@@ -355,14 +354,6 @@ def photos():
     return render_template("templates/photoGalery/_main.html", groups=groups)
 
 
-if current_app.config["AFFICHAGE_RECHERCHE_AVANCEE"]:
-
-    @main.route("/<lang_code>/recherche", methods=["GET"])
-    @main.route("/recherche", methods=["GET"])
-    def advanced_search():
-        return render_template(
-            "templates/core/advanced_search.html",
-        )
 
 
 @main.route("/<lang_code>/static/<page>", methods=["GET", "POST"])

--- a/atlas/atlasRoutes.py
+++ b/atlas/atlasRoutes.py
@@ -113,7 +113,8 @@ if current_app.config["ORGANISM_MODULE"]:
 def index():
 
     if current_app.config["AFFICHAGE_TERRITOIRE_OBS"]:
-        listTaxons = vmTaxonsRepository.getTaxonsTerritory()
+        # listTaxons = vmTaxonsRepository.getTaxonsTerritory()
+        listTaxons = []
     else:
         listTaxons = []
 

--- a/atlas/modeles/entities/vmObservations.py
+++ b/atlas/modeles/entities/vmObservations.py
@@ -48,3 +48,16 @@ class VmObservationsMailles(db.Model):
     annee: Mapped[int] = mapped_column()
     id_observations: Mapped[List[int]] = mapped_column(ARRAY(Integer))
     type_code: Mapped[str] = mapped_column(String(25))
+
+
+class VMCorMailleObservation(db.Model):
+    """
+    Table des observations par maille
+    """
+
+    __tablename__ = "vm_cor_maille_observation"
+    __table_args__ = {"schema": "atlas"}
+
+    id_maille: Mapped[int] = mapped_column(primary_key=True)
+    id_observation: Mapped[int] = mapped_column(primary_key=True)
+    type_code: Mapped[str] = mapped_column(String(25))

--- a/atlas/modeles/entities/vmTaxons.py
+++ b/atlas/modeles/entities/vmTaxons.py
@@ -37,6 +37,10 @@ class VmTaxons(db.Model):
         "VmCorTaxonAttribut", back_populates="taxon"
     )
 
+    def shorten_name(self):
+        shorten_nom_vern = self.nom_vern.split(",")[0] if self.nom_vern else ""
+        return shorten_nom_vern + " | <i>" + self.lb_nom + " </i>"
+
 
 class VmCorTaxonAttribut(db.Model):
     __tablename__ = "vm_cor_taxon_attribut"

--- a/atlas/modeles/repositories/vmObservationsMaillesRepository.py
+++ b/atlas/modeles/repositories/vmObservationsMaillesRepository.py
@@ -24,10 +24,10 @@ def format_taxon_name(observation):
     return taxon_name_formated
 
 
-def getObservationsMaillesChilds(filters={}, with_taxons=False, with_media=False):
+def getObservationsMaillesChilds(filters={}, with_taxons=False):
     """
     Retourne un geojson sous forme de maille des observations
-    Le geojson contient les paramètre suivant :
+    Le geojson contient les propriétés suivantes :
         - id_maille
         - type_code : le type de maille à la laquelle la géométrie a floutée
         - last_obs_year : l'année à laquel la dernière observation a été faite dans la maille
@@ -97,7 +97,6 @@ def getObservationsMaillesChilds(filters={}, with_taxons=False, with_media=False
                 datetime(int(filters["year_min"]), 1,1), datetime(int(filters["year_max"]), 12, 31))
             )
     if "id_area" in filters and filters["id_area"]:
-        print(filters["id_area"])
         query = query.where(exists(
                 select(true()).select_from(VmCorAreaSynthese).where(
                     (VmCorAreaSynthese.id_area == filters["id_area"]) & (VmCorAreaSynthese.id_synthese == VmObservations.id_observation)

--- a/atlas/modeles/repositories/vmObservationsMaillesRepository.py
+++ b/atlas/modeles/repositories/vmObservationsMaillesRepository.py
@@ -1,10 +1,11 @@
 import json
+from datetime import datetime
 
 from geojson import Feature, FeatureCollection
-from sqlalchemy.sql import text, func, any_, extract, literal, cast, select
+from sqlalchemy.sql import text, func, any_, extract, literal, cast, select, exists, true
 from sqlalchemy import Interval
 
-from atlas.modeles.entities.vmObservations import VmObservations, VmObservationsMailles
+from atlas.modeles.entities.vmObservations import VmObservations, VmObservationsMailles, VMCorMailleObservation
 from atlas.modeles.entities.vmAreas import VmAreas, VmCorAreaSynthese
 from atlas.modeles.entities.vmTaxons import VmTaxons
 from atlas.modeles.entities.vmMedias import VmMedias
@@ -12,56 +13,6 @@ from atlas.modeles.utils import deleteAccent, findPath
 from atlas.app import create_app
 from atlas.env import db
 from flask import current_app
-
-
-def getObservationsMaillesTerritorySpecies(cd_ref):
-    """
-    Retourne les mailles et le nombre d'observation par maille pour un taxon et ses enfants
-    sous forme d'un geojson
-    """
-    query = func.atlas.find_all_taxons_childs(cd_ref)
-    taxons_ids = db.session.scalars(query).all()
-    taxons_ids.append(cd_ref)
-    query = (
-        db.session.query(
-            VmObservationsMailles.id_maille,
-            VmAreas.area_geojson,
-            func.max(extract("year", VmObservations.dateobs)).label("last_obs_year"),
-            VmObservationsMailles.nbr.label("obs_nbr"),
-            VmObservationsMailles.type_code,
-        )
-        .join(
-            VmObservations,
-            VmObservations.id_observation == any_(VmObservationsMailles.id_observations),
-        )
-        .join(
-            VmAreas,
-            VmAreas.id_area == VmObservationsMailles.id_maille,
-        )
-        .filter(VmObservations.cd_ref == any_(taxons_ids))
-        .group_by(
-            VmObservationsMailles.id_maille,
-            VmAreas.area_geojson,
-            VmObservationsMailles.nbr,
-            VmObservationsMailles.type_code,
-        )
-    )
-
-    return FeatureCollection(
-        [
-            Feature(
-                id=o.id_maille,
-                geometry=json.loads(o.area_geojson),
-                properties={
-                    "id_maille": o.id_maille,
-                    "type_code": o.type_code,
-                    "nb_observations": int(o.obs_nbr),
-                    "last_observation": o.last_obs_year,
-                },
-            )
-            for o in query.all()
-        ]
-    )
 
 
 def format_taxon_name(observation):
@@ -73,37 +24,86 @@ def format_taxon_name(observation):
     return taxon_name_formated
 
 
-def getObservationsMaillesChilds(cd_ref, year_min=None, year_max=None):
+def getObservationsMaillesChilds(filters={}, with_taxons=False, with_media=False):
     """
-    Retourne les mailles et le nombre d'observation par maille pour un taxon et ses enfants
-    sous forme d'un geojson
-    """
-    query = func.atlas.find_all_taxons_childs(cd_ref)
-    taxons_ids = db.session.scalars(query).all()
-    taxons_ids.append(cd_ref)
+    Retourne un geojson sous forme de maille des observations
+    Le geojson contient les paramètre suivant :
+        - id_maille
+        - type_code : le type de maille à la laquelle la géométrie a floutée
+        - last_obs_year : l'année à laquel la dernière observation a été faite dans la maille
+        - obs_nbr : le nombre d'observation dans la maille
+        - taxons (optionnel: si with taxon est True) : une liste des taxons dans la maille
+    Parameters
+    ----------
+    filters : dict, optional
+        dictionnaire des filtres de la query
+        Filtres disponible :
+            - year_min / year_max : filtre les observation dans des bornes d'année
+            - cd_ref : renvoie que les observation de ce taxon et de ces enfants
+            - id_area : renvoie uniquement les observations présente dans l'aire demandée
+    with_taxons : bool, optional
+        - Permet d'ajouter la liste des taxon d'une maille au Geojson
 
-    query = (
-        db.session.query(
-            VmObservationsMailles.id_maille,
+    Returns
+    -------
+    Geosjon
+    """
+    taxons_ids = []
+    if "cd_ref" in filters and filters["cd_ref"]:
+        query_child = func.atlas.find_all_taxons_childs(filters["cd_ref"])
+        taxons_ids = db.session.scalars(query_child).all()
+        taxons_ids.append(int(filters["cd_ref"]))
+
+    query_select = [
+            VMCorMailleObservation.id_maille,
             VmAreas.area_geojson,
-            VmObservationsMailles.type_code,
-            func.max(VmObservationsMailles.annee).label("last_obs_year"),
-            func.sum(VmObservationsMailles.nbr).label("obs_nbr"),
+            VMCorMailleObservation.type_code,
+            func.max(func.date_part('year', VmObservations.dateobs)).label("last_obs_year"),
+            func.count(VmObservations.id_observation).label("obs_nbr"),
+    ]
+    if with_taxons:
+        query_select.append(
+            func.json_agg(
+                func.distinct(
+                    func.jsonb_build_object(
+                        'name', (func.concat(func.coalesce(VmTaxons.nom_vern + ' | ', '') + VmTaxons.lb_nom)),
+                        'cdRef', VmTaxons.cd_ref
+                    )
+                )
+            ).label('taxons'),
         )
-        .join(
-            VmAreas,
-            VmAreas.id_area == VmObservationsMailles.id_maille,
-        )
-        .filter(VmObservationsMailles.cd_ref == any_(taxons_ids))
-        .group_by(
-            VmObservationsMailles.id_maille,
+    query = select(
+        *query_select
+    ).select_from(VmObservations).join(
+        VMCorMailleObservation, VMCorMailleObservation.id_observation == VmObservations.id_observation
+    ).join(
+        VmAreas, VmAreas.id_area == VMCorMailleObservation.id_maille
+    ).group_by(
+            VMCorMailleObservation.id_maille,
             VmAreas.area_geojson,
-            VmObservationsMailles.type_code,
-        )
+            VMCorMailleObservation.type_code,
     )
-    if year_min and year_max:
-        query = query.filter(VmObservationsMailles.annee.between(str(year_min), str(year_max)))
-
+    if with_taxons:
+        query = query.join(
+                VmTaxons, VmTaxons.cd_ref == VmObservations.cd_ref
+            )
+    if taxons_ids:
+        query = query.where(
+             VmObservations.cd_ref == any_(taxons_ids)
+        )
+    if ("year_min" in filters and filters["year_min"]) and ("year_max" in filters and filters["year_max"] ):
+        query = query.where(
+            VmObservations.dateobs.between(
+                datetime(int(filters["year_min"]), 1,1), datetime(int(filters["year_max"]), 12, 31))
+            )
+    if "id_area" in filters and filters["id_area"]:
+        print(filters["id_area"])
+        query = query.where(exists(
+                select(true()).select_from(VmCorAreaSynthese).where(
+                    (VmCorAreaSynthese.id_area == filters["id_area"]) & (VmCorAreaSynthese.id_synthese == VmObservations.id_observation)
+                )
+            )
+        )
     return FeatureCollection(
         [
             Feature(
@@ -114,93 +114,58 @@ def getObservationsMaillesChilds(cd_ref, year_min=None, year_max=None):
                     "type_code": o.type_code,
                     "nb_observations": int(o.obs_nbr),
                     "last_observation": o.last_obs_year,
+                    "taxons": o.taxons if with_taxons else None
                 },
             )
-            for o in query.all()
+            for o in db.session.execute(query).all()
         ]
     )
-
-
-def territoryObservationsMailles():
-    features = (
-        db.session.query(
-            func.count(VmObservations.id_observation).label("nb_observations"),
-            func.count(func.distinct(VmObservations.cd_ref)).label("nb_cd_ref"),
-            func.json_agg(
-                func.distinct(
-                    func.jsonb_build_object(
-                        'name', func.concat_ws(' | ', VmTaxons.nom_vern, VmTaxons.lb_nom),
-                        'cdRef', VmTaxons.cd_ref
-                    )
-                )
-            ).label("taxons"),
-            VmObservationsMailles.type_code,
-            VmObservationsMailles.id_maille,
-            VmAreas.area_geojson
-        )
-        .join(VmObservationsMailles, 
-              VmObservations.id_observation == func.any(VmObservationsMailles.id_observations))
-        .join(VmAreas, VmAreas.id_area == VmObservationsMailles.id_maille)
-        .join(VmTaxons, VmTaxons.cd_ref == VmObservations.cd_ref)
-        .group_by(VmObservationsMailles.type_code, VmObservationsMailles.id_maille, VmAreas.area_geojson)
-    )
-    return FeatureCollection(
-            [
-                Feature(
-                    id=o.id_maille,
-                    geometry=json.loads(o.area_geojson),
-                    properties={
-                        "nb_observations": o.nb_observations,
-                        "nb_cd_ref": o.nb_cd_ref,
-                        "taxons": o.taxons,
-                        "type_code": o.type_code,
-                        "id_maille": o.id_maille 
-                    }
-                )
-                for o in features.all()
-            ]
-        )
-
 
 # last observation for index.html
 def lastObservationsMailles(mylimit, idPhoto):
     query = (
-        select(
-            VmObservationsMailles,
-            VmTaxons.lb_nom, VmTaxons.nom_vern, VmTaxons.group2_inpn,
-            VmObservations.dateobs, VmObservations.altitude_retenue,
-            VmObservations.id_observation, VmObservations.cd_ref,
-            VmMedias.url,  VmMedias.chemin, VmMedias.id_media,
-            VmAreas.area_geojson
-
+            select(
+                VmObservations,
+                VMCorMailleObservation,
+                VmTaxons.lb_nom, 
+                VmTaxons.nom_vern, 
+                VmTaxons.group2_inpn,
+                VmMedias.url,  
+                VmMedias.chemin, 
+                VmMedias.id_media,
+                VmAreas.area_geojson
+            )
+            .select_from(
+                VmObservations
+            ).join(
+                VMCorMailleObservation, VMCorMailleObservation.id_observation == VmObservations.id_observation
+            ).join(VmTaxons, VmTaxons.cd_ref == VmObservations.cd_ref)
+            .join(VmAreas, VmAreas.id_area == VMCorMailleObservation.id_maille)
+            .outerjoin(
+                VmMedias, (VmMedias.cd_ref == VmObservations.cd_ref) & (VmMedias.id_type == idPhoto)
+            ).where(VmObservations.dateobs >= (func.current_timestamp() - cast(literal(mylimit), Interval)))
+            .order_by(VmObservations.dateobs.desc())
         )
-        .join(VmObservations, 
-              VmObservations.id_observation == func.any(VmObservationsMailles.id_observations))
-        .join(VmTaxons, VmTaxons.cd_ref == VmObservations.cd_ref)
-        .join(VmAreas, VmAreas.id_area == VmObservationsMailles.id_maille)
-        .outerjoin(
-            VmMedias, (VmMedias.cd_ref == VmObservations.cd_ref) & (VmMedias.id_type == idPhoto)
-        )
-        .filter(VmObservations.dateobs >= (func.current_timestamp() - cast(literal(mylimit), Interval)))
-        .order_by(VmObservations.dateobs.desc())
-    )
 
     results = db.session.execute(query).mappings().all()
+    
     obsList = list()
     for row in results:
-        obj = row["VmObservationsMailles"] # Objet ORM VmObservationsMailles
+        print(row)
+        vm_obj_maille_obj = row["VMCorMailleObservation"] # Objet ORM VmObservationsMailles
+        vm_obs_obj = row["VmObservations"]
         if row.nom_vern:
             inter = row.nom_vern.split(",")
             taxon = inter[0] + " | <i>" + row.lb_nom + "</i>"
         else:
             taxon = "<i>" + row.lb_nom + "</i>"
         temp = {
-            "id_observation": row.id_observation,
-            "id_maille": obj.id_maille,
-            "type_code": obj.type_code,
-            "cd_ref": row.cd_ref,
-            "dateobs": row.dateobs,
-            "altitude_retenue": row.altitude_retenue,
+            "id_observation": vm_obs_obj.id_observation,
+            "id_maille": vm_obj_maille_obj.id_maille,
+            "type_code": vm_obj_maille_obj.type_code,
+            "cd_ref": vm_obs_obj.cd_ref,
+            "dateobs": vm_obs_obj.dateobs,
+            "altitude_retenue": vm_obs_obj.altitude_retenue,
             "taxon": taxon,
             "geojson_maille": json.loads(row.area_geojson),
             "group2_inpn": deleteAccent(row.group2_inpn),
@@ -208,105 +173,4 @@ def lastObservationsMailles(mylimit, idPhoto):
             "id_media": row.id_media,
         }
         obsList.append(temp)
-
     return obsList
-
-
-def getObservationsByArea(id_area):
-    obs_in_area = (
-        select(
-            VmObservations.id_observation,
-            VmObservations.cd_ref,
-            func.date_part('year', VmObservations.dateobs).label("annee")
-        )
-        .join(VmCorAreaSynthese, 
-              VmCorAreaSynthese.id_synthese == VmObservations.id_observation)
-        .filter(VmCorAreaSynthese.id_area == id_area)
-        .subquery("obs_in_area")
-    )
-    features = (
-        db.session.query(
-            func.count(obs_in_area.c.id_observation).label("nb_observations"),
-            func.count(func.distinct(obs_in_area.c.cd_ref)).label("nb_cd_ref"),
-            func.json_agg(
-                func.distinct(
-                    func.jsonb_build_object(
-                        'name', (func.concat(func.coalesce(VmTaxons.nom_vern + ' | ', '') + VmTaxons.lb_nom)),
-                        'cdRef', VmTaxons.cd_ref
-                    ) 
-                )
-            ).label('taxons'),
-            VmObservationsMailles.type_code,
-            VmObservationsMailles.id_maille,
-            VmAreas.area_geojson
-        )
-        .join(VmObservationsMailles, obs_in_area.c.id_observation == func.any(VmObservationsMailles.id_observations))
-        .join(VmAreas, VmAreas.id_area == VmObservationsMailles.id_maille)
-        .join(VmTaxons, VmTaxons.cd_ref == obs_in_area.c.cd_ref)
-        .group_by(VmObservationsMailles.type_code, VmObservationsMailles.id_maille, VmAreas.area_geojson)
-    )
-
-    return FeatureCollection(
-            [
-                Feature(
-                    id=o.id_maille,
-                    geometry=json.loads(o.area_geojson),
-                    properties={
-                        "nb_observations": o.nb_observations,
-                        "nb_cd_ref": o.nb_cd_ref,
-                        "taxons": o.taxons,
-                        "type_code": o.type_code,
-                        "id_maille": o.id_maille
-                    }
-                )
-                for o in features.all()
-            ]
-        )
-
-
-# Use for API
-def getObservationsTaxonAreaMaille(id_area, cd_ref):
-    obs_in_area = (
-        select(
-            VmObservations.id_observation,
-            VmObservations.cd_ref,
-            func.date_part('year', VmObservations.dateobs).label("annee"),
-            func.count(VmObservations.id_observation).label("nb_observations")
-        )
-        .join(VmCorAreaSynthese, VmCorAreaSynthese.id_synthese == VmObservations.id_observation)
-        .filter(VmCorAreaSynthese.id_area == id_area, VmObservations.cd_ref == cd_ref)
-        .group_by(VmObservations.id_observation, VmObservations.cd_ref, func.date_part('year', VmObservations.dateobs))
-        .subquery("obs_in_area")
-    ) 
-    query = (
-        select(
-            obs_in_area.c.cd_ref,
-            obs_in_area.c.annee,
-            obs_in_area.c.nb_observations,
-            VmObservationsMailles.type_code,
-            VmObservationsMailles.id_maille,
-            VmAreas.area_geojson,
-            VmTaxons.nom_vern,
-            VmTaxons.lb_nom
-        )
-        .join(VmObservationsMailles, 
-              obs_in_area.c.id_observation == func.any(VmObservationsMailles.id_observations))
-        .join(VmAreas, VmAreas.id_area == VmObservationsMailles.id_maille)
-        .join(VmTaxons, VmTaxons.cd_ref == obs_in_area.c.cd_ref)
-        .order_by(obs_in_area.c.annee.desc())
-    )
-    observations = db.session.execute(query).all()
-    tabObs = list()
-    for o in observations:
-        temp = {
-            "id_maille": o.id_maille,
-            "cd_ref": o.cd_ref,
-            "taxon": format_taxon_name(o),
-            "type_code": o.type_code,
-            "nb_observations": o.nb_observations,
-            "annee": o.annee,
-            "geojson_maille": json.loads(o.area_geojson),
-        }
-        tabObs.append(temp)
-
-    return tabObs

--- a/atlas/modeles/repositories/vmTaxonsRepository.py
+++ b/atlas/modeles/repositories/vmTaxonsRepository.py
@@ -14,6 +14,7 @@ from atlas.env import db
 
 
 def getTaxonsTerritory():
+    """ Renvoie la liste de taxon de tout le terrtoire de l'atlas"""
     id_type = current_app.config["ATTR_MAIN_PHOTO"]
     req = (
         select(
@@ -48,7 +49,7 @@ def getTaxonsTerritory():
         .distinct()
     )
     results = db.session.execute(req).all()
-    taxonCommunesList = list()
+    taxon_list = list()
     nbObsTotal = 0
     for r in results:
         temp = {
@@ -63,9 +64,9 @@ def getTaxonsTerritory():
             "path": utils.findPath(r),
             "id_media": r.id_media,
         }
-        taxonCommunesList.append(temp)
+        taxon_list.append(temp)
         nbObsTotal = nbObsTotal + r.nb_obs
-    return {"taxons": taxonCommunesList, "nbObsTotal": nbObsTotal}
+    return {"taxons": taxon_list, "nbObsTotal": nbObsTotal}
 
 
 # With distinct the result in a array not an object, 0: lb_nom, 1: nom_vern

--- a/atlas/static/mapAreas.js
+++ b/atlas/static/mapAreas.js
@@ -64,10 +64,6 @@ generateLegende(htmlLegend);
 var baseUrl =  configuration.URL_APPLICATION + "/api/observations/" + areaInfos.areaCode
 
 
-function displayObsGridBaseUrl() {
-    return configuration.URL_APPLICATION + "/api/observationsMaille/"
-}
-
 // display observation on click
 function displayObsTaxon(id_area, cd_ref) {
   $.ajax({
@@ -96,12 +92,13 @@ function displayObsTaxon(id_area, cd_ref) {
 }
 
 function displayObs(id_area) {
-    let url = `${configuration.URL_APPLICATION}/api/area/${id_area}`;
+    let url = `${configuration.URL_APPLICATION}/api/observationsMaille?id_area=${id_area}&with_taxons=true`;
     // si on est en mode point on rajoute une limite au nombre d'obs
     // si on est en maille on renvoie toutes les données aggregées par maille
-    if (!configuration.AFFICHAGE_MAILLE) {
-        url +=`?limit=${configuration["NB_LAST_OBS"]}`
-    }
+
+    // if (!configuration.AFFICHAGE_MAILLE) {
+    //     url +=`?limit=${configuration["NB_LAST_OBS"]}`
+    // }
     $("#loaderSpinner").show();
     fetch(url)
         .then(data => {
@@ -125,10 +122,11 @@ function displayObs(id_area) {
 function displayObsTaxonMaille(areaCode, cd_ref) {
     $.ajax({
         url:
-            displayObsGridBaseUrl() +
-            areaCode +
-            "/" +
-            cd_ref,
+        configuration.URL_APPLICATION + "/api/observationsMaille",
+        data: {
+            "id_area": areaCode,
+            "cd_ref": cd_ref
+        },
         dataType: "json",
         beforeSend: function () {
             $("#loaderSpinner").show();
@@ -139,8 +137,8 @@ function displayObsTaxonMaille(areaCode, cd_ref) {
             map.removeLayer(currentLayer);
         }
         clearOverlays();
-        const geojsonMaille = generateGeoJsonMailleLastObs(observations);
-        displayMailleLayerFicheEspece(geojsonMaille);
+        // const geojsonMaille = generateGeoJsonMailleLastObs(observations);
+        displayMailleLayerFicheEspece(observations);
     });
 }
 

--- a/atlas/static/mapAreas.js
+++ b/atlas/static/mapAreas.js
@@ -61,44 +61,16 @@ htmlLegend = configuration.AFFICHAGE_MAILLE
 generateLegende(htmlLegend);
 
 
-var baseUrl =  configuration.URL_APPLICATION + "/api/observations/" + areaInfos.areaCode
-
-
-// display observation on click
-function displayObsTaxon(id_area, cd_ref) {
-  $.ajax({
-    url:
-      configuration.URL_APPLICATION +
-      "/api/observations/" +
-      id_area +
-      "/" +
-      cd_ref,
-    dataType: "json",
-      beforeSend: function () {
-          $("#loaderSpinner").show();
-    }
-  }).done(function (observations) {
-    $("#loaderSpinner").hide();
-    if (currentLayer) {
-      map.removeLayer(currentLayer);
-    }
-    if (configuration.AFFICHAGE_MAILLE) {
-        displayMailleLayerLastObs(observations);
-        clearOverlays()
-    } else {
-        displayMarkerLayerPointArea(observations);
-    }
-    })
-}
 
 function displayObs(id_area) {
-    let url = `${configuration.URL_APPLICATION}/api/observationsMaille?id_area=${id_area}&with_taxons=true`;
     // si on est en mode point on rajoute une limite au nombre d'obs
     // si on est en maille on renvoie toutes les données aggregées par maille
-
-    // if (!configuration.AFFICHAGE_MAILLE) {
-    //     url +=`?limit=${configuration["NB_LAST_OBS"]}`
-    // }
+    let url;
+    if (!configuration.AFFICHAGE_MAILLE) {        
+        url = `${configuration.URL_APPLICATION}/api/observationsPoint?id_area=${id_area}&limit=100&&with_taxons=true`;
+    } else{
+        url = `${configuration.URL_APPLICATION}/api/observationsMaille?id_area=${id_area}&with_taxons=true`;
+    }
     $("#loaderSpinner").show();
     fetch(url)
         .then(data => {
@@ -107,9 +79,9 @@ function displayObs(id_area) {
         .then(observations => {
 
             if (configuration.AFFICHAGE_MAILLE) {
-                displayMailleLayer(observations);
-            } else {
-                displayMarkerLayerPointLastObs(observations)
+                displayGeojsonMailles(observations);
+            } else {                
+                displayGeoJsonPoint(observations)
             }
             $("#loaderSpinner").hide();
         })
@@ -137,9 +109,30 @@ function displayObsTaxonMaille(areaCode, cd_ref) {
             map.removeLayer(currentLayer);
         }
         clearOverlays();
-        // const geojsonMaille = generateGeoJsonMailleLastObs(observations);
         displayMailleLayerFicheEspece(observations);
     });
+}
+
+function displayObsTaxon(id_area, cd_ref) {
+  $.ajax({
+    url:
+      configuration.URL_APPLICATION +
+      "/api/observationsPoint",
+    data: {
+        "id_area": id_area,
+        "cd_ref": cd_ref
+    },
+    dataType: "json",
+      beforeSend: function () {
+          $("#loaderSpinner").show();
+    }
+  }).done(function (observations) {
+    $("#loaderSpinner").hide();
+    if (currentLayer) {
+      map.removeLayer(currentLayer);
+    }
+    displayGeoJsonPoint(observations);
+    })
 }
 
 function refreshObsArea(elem) {

--- a/atlas/static/mapGenerator.js
+++ b/atlas/static/mapGenerator.js
@@ -566,15 +566,14 @@ function generateGeojsonPointLastObs(observationsPoint) {
     return myGeoJson;
 }
 
-function displayMarkerLayerPointLastObs(observationsPoint) {
-  myGeoJson = generateGeojsonPointLastObs(observationsPoint);
-  if (typeof customizeMarkerStyle == "undefined") {
+function displayGeoJsonPoint(geojson) {
+if (typeof customizeMarkerStyle == "undefined") {
     customizeMarkerStyle = function (feature) {
       return {};
     };
   }
 
-  currentLayer = L.geoJson(myGeoJson, {
+  currentLayer = L.geoJson(geojson, {
     onEachFeature: onEachFeaturePointLastObs,
     pointToLayer: function (feature, latlng) {
       return L.circleMarker(
@@ -583,35 +582,13 @@ function displayMarkerLayerPointLastObs(observationsPoint) {
       );
     },
   });
-
   map.addLayer(currentLayer);
-  if (typeof divLegendeFicheAreaHome !== "undefined") {
-    legend.onAdd = function (map) {
-      var div = L.DomUtil.create("div", "info legend");
-      div.innerHTML = divLegendeFicheAreaHome;
-      return div;
-    };
-    legend.addTo(map);
-  }
 }
 
-function displayMarkerLayerPointArea(observationsPoint) {
+function displayMarkerLayerPointLastObs(observationsPoint) {  
+      
   myGeoJson = generateGeojsonPointLastObs(observationsPoint);
-  if (typeof customizeMarkerStyle == "undefined") {
-    customizeMarkerStyle = function (feature) {
-      return {};
-    };
-  }
-
-  currentLayer = L.geoJson(myGeoJson, {
-    onEachFeature: onEachFeaturePointArea,
-    pointToLayer: function (feature, latlng) {
-      return L.circleMarker(
-        latlng,
-        customizeMarkerStyle(feature)
-      );
-    },
-  });
+  displayGeoJsonPoint(myGeoJson)
 
   map.addLayer(currentLayer);
   if (typeof divLegendeFicheAreaHome !== "undefined") {
@@ -623,6 +600,7 @@ function displayMarkerLayerPointArea(observationsPoint) {
     legend.addTo(map);
   }
 }
+
 
 //  ** MAILLE ***
 
@@ -807,7 +785,7 @@ function generateGeoJsonMailleLastObs(observations, isRefresh=false) {
     };
 }
 
-function displayMailleLayer(observationsMaille) {
+function displayGeojsonMailles(observationsMaille) {
 
     // Get all different type code
     observationsMaille.features.forEach(elem => {

--- a/atlas/static/mapHome.js
+++ b/atlas/static/mapHome.js
@@ -70,14 +70,16 @@ generateLegende(htmlLegend);
         $("#loaderSpinner").show();
 
         // display maille layer
-        fetch(`/api/observationsMailleTerritory`)
-            .then(response => response.json())
-            .then(data => {
-                observations = data
-                displayMailleLayer(observations);
-                $("#loaderSpinner").hide();
+        fetch(`/api/observationsMaille?`+ new URLSearchParams({
+            "with_taxons": true
+        }))
+        .then(response => response.json())
+        .then(data => {
+            observations = data
+            displayMailleLayer(observations);
+            $("#loaderSpinner").hide();
 
-            })
+        })
 
 
         // interaction list - map

--- a/atlas/static/mapHome.js
+++ b/atlas/static/mapHome.js
@@ -10,23 +10,6 @@ $('#map').click(function(){
 })
 
 
-
-function displayObsTaxonMaille(cd_ref) {
-    $.ajax({
-        url: `${configuration.URL_APPLICATION}/api/observations/${cd_ref}`,
-        dataType: "json",
-        beforeSend: function () {
-            $("#loaderSpinner").show();
-        }
-    }).done(function (observations) {
-        $("#loaderSpinner").hide();
-        map.removeLayer(currentLayer);
-        clearOverlays()
-
-        displayMailleLayerFicheEspece(observations);
-    });
-}
-
 function refreshTerritoryArea(elem) {
     document.querySelector("#taxonList .current")?.classList.remove("current")
     elem.currentTarget.classList.add('current');
@@ -76,7 +59,7 @@ generateLegende(htmlLegend);
         .then(response => response.json())
         .then(data => {
             observations = data
-            displayMailleLayer(observations);
+            displayGeojsonMailles(observations);
             $("#loaderSpinner").hide();
 
         })

--- a/atlas/static/mapMailles.js
+++ b/atlas/static/mapMailles.js
@@ -26,7 +26,7 @@ var myGeoJson;
 var compteurLegend = 0; // compteur pour ne pas rajouter la légende à chaque fois
 
 $.ajax({
-    url: configuration.URL_APPLICATION + "/api/observationsMaille/" + cd_ref,
+    url: configuration.URL_APPLICATION + "/api/observationsMaille?cd_ref=" + cd_ref,
     dataType: "json",
     beforeSend: function() {
         $("#loaderSpinner").show();
@@ -55,10 +55,11 @@ $.ajax({
         map.removeLayer(currentLayer);
         clearOverlays()
         $.ajax({
-            url: configuration.URL_APPLICATION + "/api/observationsMaille/" + cd_ref,
+            url: configuration.URL_APPLICATION + "/api/observationsMaille",
             dataType: "json",
             type: "get",
             data: {
+                cd_ref: cd_ref,
                 year_min: yearMin,
                 year_max: yearMax
             },

--- a/atlas/static/mapPoint.js
+++ b/atlas/static/mapPoint.js
@@ -76,7 +76,7 @@ $.ajax({
                     $.ajax({
                         url:
                             configuration.URL_APPLICATION +
-                            "/api/observationsMaille" +
+                            "/api/observationsMaille",
                             dataType: "json",
                             type: "get",
                             data: {

--- a/atlas/static/mapPoint.js
+++ b/atlas/static/mapPoint.js
@@ -76,13 +76,13 @@ $.ajax({
                     $.ajax({
                         url:
                             configuration.URL_APPLICATION +
-                            "/api/observationsMaille/" +
-                            cd_ref,
-                        dataType: "json",
-                        type: "get",
-                        data: {
-                            year_min: yearMin,
-                            year_max: yearMax
+                            "/api/observationsMaille" +
+                            dataType: "json",
+                            type: "get",
+                            data: {
+                                cd_ref: cd_ref,
+                                year_min: yearMin,
+                                year_max: yearMax
                         },
                         beforeSend: function () {
                             $("#loaderSpinner").show();

--- a/data/atlas/13.atlas.vm_observations_mailles.sql
+++ b/data/atlas/13.atlas.vm_observations_mailles.sql
@@ -1,41 +1,13 @@
-CREATE MATERIALIZED VIEW atlas.vm_observations_mailles AS
-    WITH distinct_obs AS (
-        -- si l'observation est une ligne ou un polygone elle peut intersecté plusieur fois le même type de zonage
-        SELECT DISTINCT ON (o.id_observation, cas.type_code)
-            o.id_observation,
-            o.cd_ref,
-            date_part('year', o.dateobs) AS annee,
-            cas.id_area as id_maille,
-            cas.type_code
-        FROM atlas.vm_observations AS o
-            LEFT JOIN atlas.vm_cor_area_synthese AS cas
-                ON cas.id_synthese = o.id_observation
-            JOIN atlas.cor_sensitivity_area_type AS csat
-                ON (
-                    o.cd_sensitivity = csat.sensitivity_code
-                    AND cas.type_code = csat.area_type_code
-                )
-    )
-    SELECT
-        o.cd_ref,
-        o.annee,
-        o.id_maille,
-        o.type_code,
-        COUNT(o.id_observation) AS nbr,
-        ARRAY_AGG(o.id_observation) AS id_observations
-    FROM distinct_obs AS o
-    GROUP BY o.cd_ref, o.annee, o.id_maille, o.type_code
-    ORDER BY o.cd_ref, o.annee
+CREATE MATERIALIZED VIEW atlas.vm_cor_maille_observation
+TABLESPACE pg_default
+AS SELECT o_1.id_observation,
+    cas.id_area AS id_maille,
+    cas.type_code
+   FROM atlas.vm_observations o_1
+     JOIN atlas.vm_cor_area_synthese cas ON cas.id_synthese = o_1.id_observation
+     JOIN atlas.cor_sensitivity_area_type csat ON o_1.cd_sensitivity::text = csat.sensitivity_code::text AND cas.type_code::text = csat.area_type_code::text
 WITH DATA;
 
-CREATE UNIQUE INDEX ON atlas.vm_observations_mailles
-    USING btree (cd_ref, annee, id_maille);
-
-CREATE INDEX ON atlas.vm_observations_mailles
-    USING btree (annee);
-
-CREATE INDEX ON atlas.vm_observations_mailles
-    USING gin (id_observations);
-
-CREATE INDEX ON atlas.vm_observations_mailles
-    USING btree (id_maille, cd_ref);
+-- View indexes:
+CREATE INDEX vm_cor_maille_observation_id_maille_idx ON atlas.vm_cor_maille_observation USING btree (id_maille);
+CREATE INDEX vm_cor_maille_observation_id_observation_idx ON atlas.vm_cor_maille_observation USING btree (id_observation);

--- a/data/atlas/20.grant.sql
+++ b/data/atlas/20.grant.sql
@@ -24,7 +24,7 @@ GRANT SELECT ON TABLE atlas.vm_cor_taxon_attribut TO :reader_user ;
 GRANT SELECT ON TABLE atlas.vm_taxons_plus_observes TO :reader_user ;
 GRANT EXECUTE ON FUNCTION atlas.find_all_taxons_childs(integer) TO :reader_user ;
 GRANT SELECT ON TABLE atlas.vm_cor_taxon_organism TO :reader_user ;
-GRANT SELECT ON TABLE atlas.vm_observations_mailles TO :reader_user ;
+GRANT SELECT ON TABLE atlas.vm_cor_maille_observation TO :reader_user ;
 GRANT SELECT ON TABLE atlas.vm_area_stats TO :reader_user ;
 GRANT SELECT ON TABLE atlas.vm_area_stats_by_taxonomy_group TO :reader_user ;
 GRANT SELECT ON TABLE atlas.vm_area_stats_by_organism TO :reader_user ;


### PR DESCRIPTION
Rationalize endpoint and maille repository
The `getObservationsMaillesChilds` and `getObservationsChilds` can be use for species sheet and territory sheet with various filters