### PR TITLE
Fix customized picto static page

### DIFF
--- a/atlas/templates/core/sideBar.html
+++ b/atlas/templates/core/sideBar.html
@@ -20,7 +20,7 @@
                    data-bs-placement="right">
                     {% if 'customized_picto' in page_values %}
                         <span>
-                            <img src="/static/custom/images/{{ page_values.customized_picto }}" height="{{ page_values.picto_height }}">
+                            <img src="{{ url_for('static', filename='custom/images/' ~ page_values.customized_picto) }}" height="{{ page_values.picto_height }}">
                         </span>
                     {% else %}
                         <span class="fas {{ page_values.picto }}"></span>
@@ -36,7 +36,7 @@
                    data-bs-placement="right">
                     {% if 'customized_picto' in page_values %}
                         <span>
-                            <img src="/static/custom/images/{{ page_values.customized_picto }}" height="{{ page_values.picto_height }}">
+                            <img src="{{ url_for('static', filename='custom/images/' ~ page_values.customized_picto) }}" height="{{ page_values.picto_height }}">
                         </span>
                     {% else %}
                         <span class="fas {{ page_values.picto }}"></span>


### PR DESCRIPTION
Fix pour l'ajout de picto customisé pour les pages static. 
Initialement GET en 404 not found car lier à /static/custom/images au lieu de /atlas/static/custom/images