### PR TITLE
Dissocier la présentation du territoire du bloc des graphiques sur la fiche territoire

### DIFF
--- a/atlas/templates/areaSheet/_main.html
+++ b/atlas/templates/areaSheet/_main.html
@@ -37,7 +37,12 @@
     <div class="info_zone_card">
         {% include 'templates/areaSheet/statArea.html' %}
     </div>
-    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION or configuration.AFFICHAGE_TAB_AREA_OBS_ESPECES or configuration.ORGANISM_MODULE %}
+    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION %}
+        <div class="info_zone_card">
+            {% include 'templates/areaSheet/descArea.html' %}
+        </div>
+    {% endif %}
+    {% if configuration.AFFICHAGE_TAB_AREA_OBS_ESPECES or configuration.ORGANISM_MODULE %}
         <div class="info_zone_card">
             {% include 'templates/areaSheet/moreZoneInfo.html' %}
         </div>

--- a/atlas/templates/areaSheet/descArea.html
+++ b/atlas/templates/areaSheet/descArea.html
@@ -1,8 +1,6 @@
 {% block descArea %}
-    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION and areaInfos.description %}
     <div class="card container info_card">
         <h5 class="mb-3">{{ _('general_presentation') }}</h5>
         {{ areaInfos.description | safe }}
     </div>
-    {% endif %}
 {% endblock %}

--- a/atlas/templates/areaSheet/descArea.html
+++ b/atlas/templates/areaSheet/descArea.html
@@ -1,0 +1,8 @@
+{% block descArea %}
+    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION and areaInfos.description %}
+    <div class="card container info_card">
+        <h5 class="mb-3">{{ _('general_presentation') }}</h5>
+        {{ areaInfos.description | safe }}
+    </div>
+    {% endif %}
+{% endblock %}

--- a/atlas/templates/areaSheet/moreZoneInfo.html
+++ b/atlas/templates/areaSheet/moreZoneInfo.html
@@ -1,12 +1,6 @@
 {% block moreZoneInfos %}
 
     <div class="card container info_card">
-        <ul class="nav nav-tabs">
-            {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION and areaInfos.description %}
-                <li class="nav-item">
-                    <a class="nav-link active" data-bs-toggle="tab" href="#general_presentation">{{ _('general_presentation') }}</a>
-                </li>
-            {% endif %}
             {% if configuration.AFFICHAGE_TAB_AREA_OBS_ESPECES %}
                 <li class="nav-item">
                     <a class="nav-link" data-bs-toggle="tab" href="#observations_and_species">{{ _('observations_and_species') }}</a>
@@ -30,11 +24,6 @@
                 <span class="visually-hidden">Loading...</span>
             </div>
 
-            {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION and areaInfos.description %}
-                <div id="general_presentation" class="tab-pane fade show active">
-                    {{ areaInfos.description | safe }}
-                </div>
-            {% endif %}
             {% if configuration.AFFICHAGE_TAB_AREA_OBS_ESPECES %}
                 <div id="observations_and_species" class="tab-pane fade">
                     <div class="infos_biodiversity">


### PR DESCRIPTION
Afficher la présentation du territoire (si renseignée dans `ref_geo.l_areas.description`) dans un bloc distinct de celui des graphiques (onglets) "Observations et espèces" | "Espèces menacées" | "Provenance des données" : 


<img width="1772" height="2151" alt="fiche_territoire" src="https://github.com/user-attachments/assets/83e170cd-3115-4693-95de-1f19a8c7bb38" />
