### PR TITLE
Corrections de coquilles de la PR #796

### DIFF
--- a/atlas/templates/areaSheet/_main.html
+++ b/atlas/templates/areaSheet/_main.html
@@ -37,7 +37,7 @@
     <div class="info_zone_card">
         {% include 'templates/areaSheet/statArea.html' %}
     </div>
-    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION %}
+    {% if configuration.AFFICHAGE_TAB_AREA_GENERAL_PRESENTATION and areaInfos.description %}
         <div class="info_zone_card">
             {% include 'templates/areaSheet/descArea.html' %}
         </div>

--- a/atlas/templates/areaSheet/moreZoneInfo.html
+++ b/atlas/templates/areaSheet/moreZoneInfo.html
@@ -1,6 +1,7 @@
 {% block moreZoneInfos %}
 
     <div class="card container info_card">
+        <ul class="nav nav-tabs">
             {% if configuration.AFFICHAGE_TAB_AREA_OBS_ESPECES %}
                 <li class="nav-item">
                     <a class="nav-link" data-bs-toggle="tab" href="#observations_and_species">{{ _('observations_and_species') }}</a>


### PR DESCRIPTION
Corrections de coquilles dans la PR #796 sur les templates de la fiche territoire : 
- suppression par erreur de `<ul> ` dans `moreZoneInfo.html`
- omission d'une partie de la condition pour l'affichage du bloc de présentation dans `_main.html`